### PR TITLE
Support multiple zones

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -204,7 +204,7 @@ resource "azurerm_linux_virtual_machine" "linux_vm" {
   availability_set_id             = var.enable_vm_availability_set == true ? element(concat(azurerm_availability_set.aset.*.id, [""]), 0) : null
   encryption_at_host_enabled      = var.enable_encryption_at_host
   proximity_placement_group_id    = var.enable_proximity_placement_group ? azurerm_proximity_placement_group.appgrp.0.id : null
-  zone                            = var.vm_availability_zone
+  zone                            = var.vm_availability_zone == null ? var.zones_list[count.index] : var.vm_availability_zone
 
   tags = merge(
     {

--- a/main.tf
+++ b/main.tf
@@ -204,7 +204,7 @@ resource "azurerm_linux_virtual_machine" "linux_vm" {
   availability_set_id             = var.enable_vm_availability_set == true ? element(concat(azurerm_availability_set.aset.*.id, [""]), 0) : null
   encryption_at_host_enabled      = var.enable_encryption_at_host
   proximity_placement_group_id    = var.enable_proximity_placement_group ? azurerm_proximity_placement_group.appgrp.0.id : null
-  zone                            = var.vm_availability_zone == null ? var.zones_list[count.index] : var.vm_availability_zone
+  zone                            = length(var.zones_list) > 0 ? var.zones_list[count.index] : var.vm_availability_zone
 
   tags = merge(
     {
@@ -298,7 +298,7 @@ resource "azurerm_windows_virtual_machine" "win_vm" {
   encryption_at_host_enabled   = var.enable_encryption_at_host
   proximity_placement_group_id = var.enable_proximity_placement_group ? azurerm_proximity_placement_group.appgrp.0.id : null
   patch_mode                   = var.patch_mode
-  zone                         = var.vm_availability_zone
+  zone                         = length(var.zones_list) > 0 ? var.zones_list[count.index] : var.vm_availability_zone
   timezone                     = var.vm_time_zone
 
   tags = merge(

--- a/variables.tf
+++ b/variables.tf
@@ -840,3 +840,9 @@ variable "require_plan" {
   default     = false
   description = "requires plan for market place images or not"
 }
+
+variable "zones_list" {
+  type        = list(string)
+  default     = []
+  description = "List of availability zones"
+}


### PR DESCRIPTION
### Jira link



### Change description

at the moment `vm_availability_zone`  does not support different zones for all the VM instances and if you send value in the field, it will put all the VMs in the same zone.  This change will allow zones to be sent in the `zone_list` as list like `["1", "2"]` so that VMs can be deployed in different zone.

### Testing done

tested here -
https://github.com/hmcts/cpp-terraform-hvault/pull/55/files
https://dev.azure.com/hmcts-cpp/cpp-apps/_build/results?buildId=154230&view=logs&j=fc4b4ecc-4d80-5b68-35db-ecb09f019833&t=5fb644f2-67fc-57d2-2613-669118b26655



### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
