### PR TITLE
Include null checks to prevent errors when managed_identity_type is not set

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -63,14 +63,14 @@ output "vm_availability_set_id" {
 
 output "linux_vm_system_assigned_identity_principal_ids" {
   description = "System assigned identity principal IDs for Linux VMs"
-  value = var.os_flavor == "linux" && contains(["SystemAssigned", "SystemAssigned, UserAssigned"], var.managed_identity_type) ? [
+  value = var.os_flavor == "linux" && var.managed_identity_type != null && contains(["SystemAssigned", "SystemAssigned, UserAssigned"], var.managed_identity_type) ? [
     for vm in azurerm_linux_virtual_machine.linux_vm : try(vm.identity[0].principal_id, null)
   ] : null
 }
 
 output "windows_vm_system_assigned_identity_principal_ids" {
   description = "System assigned identity principal IDs for Windows VMs"
-  value = var.os_flavor == "windows" && contains(["SystemAssigned", "SystemAssigned, UserAssigned"], var.managed_identity_type) ? [
+  value = var.os_flavor == "windows" && var.managed_identity_type != null && contains(["SystemAssigned", "SystemAssigned, UserAssigned"], var.managed_identity_type) ? [
     for vm in azurerm_windows_virtual_machine.win_vm : try(vm.identity[0].principal_id, null)
   ] : null
 }


### PR DESCRIPTION
### Jira link

n/a

### Change description

Include null checks to prevent errors when managed_identity_type is not set
