### PR TITLE
DTSPO-31651: main - add backup enrollment via service_criticality

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This module supports to use existing NSG group. To enable this feature, specify 
 
 VMs with `service_criticality >= 4` can be automatically enrolled into a Recovery Services Vault. The backup policy is selected automatically based on criticality.
 
-To enroll, use recovery service vault module to create the vault and policy and pass the following vars to this module call:
+To enroll, use the [recovery service vault module](https://github.com/hmcts/terraform-module-recovery-services-vault) to create the vault and policy and pass the following vars to this module call:
 
 ```terraform
 module "recovery_services_vault" {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,44 @@ Terraform module to deploy azure Windows or Linux virtual machines with Public I
 
 This module supports to use existing NSG group. To enable this feature, specify the argument `existing_network_security_group_id` with a valid resource id of the current NSG group and remove all NSG inbound rules from the module.
 
+## Backup Enrollment
+
+VMs with `service_criticality >= 4` can be automatically enrolled into a Recovery Services Vault. The backup policy is selected automatically based on criticality — criticality 4 and 5 use the `vm-crit4-5` policy.
+
+```terraform
+module "recovery_services_vault" {
+  source = "git::https://github.com/hmcts/module-terraform-azurerm-recovery-services-vault.git?ref=main"
+
+  name                = "rsv-myapp-vm-prod"
+  resource_group_name = "RG-MYAPP-PROD"
+  tags                = var.tags
+}
+
+module "virtual_machine" {
+  source = "git::https://github.com/hmcts/cpp-module-terraform-azurerm-vm.git?ref=main"
+  # ...
+  service_criticality     = 5
+  rsv_name                = module.recovery_services_vault.recovery_vault_name
+  rsv_resource_group_name = module.recovery_services_vault.recovery_vault_resource_group_name
+}
+```
+
+If the RSV is managed in a separate repository, pass the vault details as plain strings:
+
+```terraform
+module "virtual_machine" {
+  source = "git::https://github.com/hmcts/cpp-module-terraform-azurerm-vm.git?ref=main"
+  # ...
+  service_criticality     = 5
+  rsv_name                = "rsv-myapp-vm-prod"
+  rsv_resource_group_name = "RG-MYAPP-PROD"
+}
+```
+
+When `instances_count > 1`, all VMs in the group are enrolled individually into the same vault and policy.
+
+Existing callers that do not set `service_criticality`, `rsv_name`, or `rsv_resource_group_name` are unaffected — no backup resources are created.
+
 ## Resources Supported
 
 * [Linux Virtual Machine](https://www.terraform.io/docs/providers/azurerm/r/linux_virtual_machine.html)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ module "virtual_machine" {
 
 When `instances_count > 1`, all VMs in the group are enrolled individually into the same vault and policy.
 
-Existing callers that do not set `service_criticality`, `rsv_name`, or `rsv_resource_group_name` are unaffected — no backup resources are created.
+Existing module users that do not set `service_criticality`, `rsv_name`, or `rsv_resource_group_name` are unaffected — no backups will be created.
 
 ## Resources Supported
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ This module supports to use existing NSG group. To enable this feature, specify 
 
 ## Backup Enrollment
 
-VMs with `service_criticality >= 4` can be automatically enrolled into a Recovery Services Vault. The backup policy is selected automatically based on criticality — criticality 4 and 5 use the `vm-crit4-5` policy.
+VMs with `service_criticality >= 4` can be automatically enrolled into a Recovery Services Vault. The backup policy is selected automatically based on criticality.
+
+To enroll, use recovery service vault module to create the vault and policy and pass the following vars to this module call:
 
 ```terraform
 module "recovery_services_vault" {

--- a/backup.tf
+++ b/backup.tf
@@ -1,0 +1,19 @@
+locals {
+  backup_policy_by_criticality = {
+    4 = "vm-crit4-5"
+    5 = "vm-crit4-5"
+  }
+  backup_policy_name       = lookup(local.backup_policy_by_criticality, var.service_criticality, null)
+  enable_backup_enrollment = local.backup_policy_name != null && var.rsv_name != null && var.rsv_resource_group_name != null
+  backup_vm_count          = local.enable_backup_enrollment ? var.instances_count : 0
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_backup_protected_vm" "main" {
+  count               = local.backup_vm_count
+  resource_group_name = var.rsv_resource_group_name
+  recovery_vault_name = var.rsv_name
+  source_vm_id        = var.os_flavor == "windows" ? azurerm_windows_virtual_machine.win_vm[count.index].id : azurerm_linux_virtual_machine.linux_vm[count.index].id
+  backup_policy_id    = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.rsv_resource_group_name}/providers/Microsoft.RecoveryServices/vaults/${var.rsv_name}/backupPolicies/${local.backup_policy_name}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -879,3 +879,30 @@ variable "os_data_disk_caching" {
   description = "The Type of Caching which should be used for the Internal OS Disk. Possible values are `None`, `ReadOnly` and `ReadWrite`"
   default     = "ReadWrite"
 }
+
+# --------------------------------------------------
+# BACKUP
+# --------------------------------------------------
+
+variable "service_criticality" {
+  description = "Service criticality rating from 1-5. VMs with criticality >= 4 are enrolled in Recovery Services Vault backup when rsv_name and rsv_resource_group_name are provided."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.service_criticality >= 1 && var.service_criticality <= 5
+    error_message = "Service criticality must be between 1 and 5."
+  }
+}
+
+variable "rsv_name" {
+  description = "Name of the Recovery Services Vault to enroll this VM in. Required when service_criticality >= 4."
+  type        = string
+  default     = null
+}
+
+variable "rsv_resource_group_name" {
+  description = "Resource group name of the Recovery Services Vault. Required when service_criticality >= 4."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31651

### Change description

- adds backup enrollment for VMs using Recovery Service Vault
- Recovery Service Vault module [here](https://github.com/hmcts/terraform-module-recovery-services-vault)

### Testing done

Please see the test in the following PR which consumed this Prs changes on the 4.x branch: https://github.com/hmcts/cpp-terraform-azurerm-elasticsearch/pull/21

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
