### PR TITLE
DTSPO-31651: 4.x branch - add backup enrollment via service_criticality

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -1,0 +1,19 @@
+locals {
+  backup_policy_by_criticality = {
+    4 = "vm-crit4-5"
+    5 = "vm-crit4-5"
+  }
+  backup_policy_name       = lookup(local.backup_policy_by_criticality, var.service_criticality, null)
+  enable_backup_enrollment = local.backup_policy_name != null && var.rsv_name != null && var.rsv_resource_group_name != null
+  backup_vm_count          = local.enable_backup_enrollment ? var.instances_count : 0
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_backup_protected_vm" "main" {
+  count               = local.backup_vm_count
+  resource_group_name = var.rsv_resource_group_name
+  recovery_vault_name = var.rsv_name
+  source_vm_id        = var.os_flavor == "windows" ? azurerm_windows_virtual_machine.win_vm[count.index].id : azurerm_linux_virtual_machine.linux_vm[count.index].id
+  backup_policy_id    = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.rsv_resource_group_name}/providers/Microsoft.RecoveryServices/vaults/${var.rsv_name}/backupPolicies/${local.backup_policy_name}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -874,3 +874,30 @@ variable "additional_ip_configs" {
   }))
   default = {}
 }
+
+# --------------------------------------------------
+# BACKUP
+# --------------------------------------------------
+
+variable "service_criticality" {
+  description = "Service criticality rating from 1-5. VMs with criticality >= 4 are enrolled in Recovery Services Vault backup when rsv_name and rsv_resource_group_name are provided."
+  type        = number
+  default     = 1
+
+  validation {
+    condition     = var.service_criticality >= 1 && var.service_criticality <= 5
+    error_message = "Service criticality must be between 1 and 5."
+  }
+}
+
+variable "rsv_name" {
+  description = "Name of the Recovery Services Vault to enroll this VM in. Required when service_criticality >= 4."
+  type        = string
+  default     = null
+}
+
+variable "rsv_resource_group_name" {
+  description = "Resource group name of the Recovery Services Vault. Required when service_criticality >= 4."
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-31651

### Change description

- adds backup enrollment for VMs using Recovery Service Vault
- Recovery Service Vault module [here](https://github.com/hmcts/terraform-module-recovery-services-vault)

### Testing done

Please see the test in the following PR which consumed this module branch: https://github.com/hmcts/cpp-terraform-azurerm-elasticsearch/pull/21

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
