### PR TITLE
DTSPO-32401 Add backup-enable variable to be used with count instead …

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -1,10 +1,5 @@
-locals {
-  enable_backup_enrollment = var.rsv_name != null && var.rsv_resource_group_name != null && var.backup_policy_id != null
-  backup_vm_count          = local.enable_backup_enrollment ? var.instances_count : 0
-}
-
 resource "azurerm_backup_protected_vm" "vm" {
-  count               = local.backup_vm_count
+  count               = var.enable_backup ? var.instances_count : 0
   resource_group_name = var.rsv_resource_group_name
   recovery_vault_name = var.rsv_name
   source_vm_id        = var.os_flavor == "windows" ? azurerm_windows_virtual_machine.win_vm[count.index].id : azurerm_linux_virtual_machine.linux_vm[count.index].id

--- a/variables.tf
+++ b/variables.tf
@@ -865,6 +865,12 @@ variable "zones_list" {
   description = "List of availability zones"
 }
 
+variable "enable_backup" {
+  type        = bool
+  default     = false
+  description = "Whether to enrol VMs into backup. Must be set to true alongside rsv_name, rsv_resource_group_name, and backup_policy_id."
+}
+
 variable "rsv_name" {
   type        = string
   default     = null


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-32401

### Change description

Problem
Running terraform destroy on environments with backup enabled (service_criticality >= 4) would fail with:


Error: Invalid count argument
  on .terraform/modules/master-vm/backup.tf line 7, in resource "azurerm_backup_protected_vm" "vm":
   7:   count = local.backup_vm_count

The "count" value depends on resource attributes that cannot be determined until apply
The root cause was that backup_vm_count was derived from var.backup_policy_id != null. Although backup_policy_id is a module variable, its value is passed from a computed resource output (module.rsv[0].crit4_5_backup_policy_id). During destroy, the RSV and backup VMs are torn down simultaneously — Terraform cannot read the RSV output at plan time, making the value unknown and the count unresolvable.

Fix
Introduce an explicit enable_backup boolean variable (default false) to control the count. This decouples the count from computed resource outputs — count now depends on a plain known value from tfvars, which Terraform can always resolve at plan time regardless of resource state.

The existing rsv_name, rsv_resource_group_name, and backup_policy_id variables are unchanged and still required to configure the backup enrollment itself.

Changes
variables.tf — add enable_backup bool variable, default false
backup.tf — replace computed local.backup_vm_count with inline var.enable_backup ? var.instances_count : 0
Consumer changes required
Callers must pass enable_backup = true alongside the existing RSV variables to enrol VMs into backup. Without it, count = 0 and no backup enrollment is performed (safe default, no breaking change for existing callers that don't pass it).

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
